### PR TITLE
OTA: upload a custom firmware.bin from the web UI

### DIFF
--- a/components/cmd_system/cmd_system.c
+++ b/components/cmd_system/cmd_system.c
@@ -16,6 +16,7 @@
 #include "esp_sleep.h"
 #include "spi_flash_mmap.h"
 #include "driver/rtc_io.h"
+#include "driver/gpio.h"
 #include "driver/uart.h"
 #include "argtable3/argtable3.h"
 #include "freertos/FreeRTOS.h"

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -104,6 +104,12 @@ static httpd_uri_t otalog_post_download = {
     .handler = otalog_post_handler,
     .user_ctx = NULL};
 
+static httpd_uri_t uploadfw_post = {
+    .uri = "/uploadfw",
+    .method = HTTP_POST,
+    .handler = uploadfw_post_handler,
+    .user_ctx = NULL};
+
 static httpd_uri_t advanced_page_download = {
     .uri = "/advanced",
     .method = HTTP_GET,
@@ -151,7 +157,7 @@ httpd_handle_t start_webserver(void)
 {
     httpd_handle_t server = NULL;
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
-    config.max_uri_handlers = 25;
+    config.max_uri_handlers = 26;
     config.stack_size = 16384;
     config.lru_purge_enable = true;
 
@@ -205,6 +211,7 @@ httpd_handle_t start_webserver(void)
         httpd_register_uri_handler(server, &ota_page_post);
         httpd_register_uri_handler(server, &otalog_page_download);
         httpd_register_uri_handler(server, &otalog_post_download);
+        httpd_register_uri_handler(server, &uploadfw_post);
         httpd_register_uri_handler(server, &portmap_page_download);
         httpd_register_uri_handler(server, &portmap_post_download);
         httpd_register_err_handler(server, HTTPD_404_NOT_FOUND, http_404_error_handler);

--- a/src/pages/ota.html
+++ b/src/pages/ota.html
@@ -54,8 +54,50 @@
                 <input type=submit value="Install latest version" class="btn btn-warning">
             </div>
         </form>
+
+        <hr class="mt-5">
+        <div class="row text-center">
+            <h2>Upload custom firmware</h2>
+        </div>
+        <div class="form-group row col-8 offset-2 mt-2">
+            <input type="file" id="fwfile" accept=".bin" class="form-control">
+        </div>
+        <div class="form-group row col-4 offset-4 mt-2">
+            <button id="fwupload" class="btn btn-danger">Flash uploaded firmware</button>
+        </div>
+        <div class="form-group row col-8 offset-2 mt-2">
+            <progress id="fwprog" max="100" value="0" style="width:100%;display:none"></progress>
+            <div id="fwstatus" class="text-center mt-2"></div>
+        </div>
+
         <div class="form-group row col-4 offset-4 mt-5"> <a href=/ class="btn btn-light">Back</a> </div>
     </div>
+    <script>
+    (function(){
+        var btn=document.getElementById('fwupload');
+        var f=document.getElementById('fwfile');
+        var prog=document.getElementById('fwprog');
+        var st=document.getElementById('fwstatus');
+        btn.addEventListener('click',function(e){
+            e.preventDefault();
+            if(!f.files||!f.files[0]){st.textContent='Choose a .bin file first.';return;}
+            if(!confirm('Flash '+f.files[0].name+' ('+f.files[0].size+' bytes)? Device will reboot.'))return;
+            btn.disabled=true;prog.style.display='block';prog.value=0;st.textContent='Uploading...';
+            var xhr=new XMLHttpRequest();
+            xhr.open('POST','/uploadfw',true);
+            xhr.setRequestHeader('Content-Type','application/octet-stream');
+            xhr.upload.onprogress=function(ev){
+                if(ev.lengthComputable){prog.value=Math.round(ev.loaded*100/ev.total);st.textContent='Uploading... '+prog.value+'%';}
+            };
+            xhr.onload=function(){
+                if(xhr.status===200){st.textContent='OK - rebooting. Refresh in 30s.';prog.value=100;}
+                else{st.textContent='Failed ('+xhr.status+'): '+xhr.responseText;btn.disabled=false;}
+            };
+            xhr.onerror=function(){st.textContent='Network error during upload.';btn.disabled=false;};
+            xhr.send(f.files[0]);
+        });
+    })();
+    </script>
 </body>
 
 </html>

--- a/src/urihandler/handler.h
+++ b/src/urihandler/handler.h
@@ -50,6 +50,7 @@ esp_err_t ota_download_get_handler(httpd_req_t *req);
 esp_err_t otalog_get_handler(httpd_req_t *req);
 esp_err_t ota_post_handler(httpd_req_t *req);
 esp_err_t otalog_post_handler(httpd_req_t *req);
+esp_err_t uploadfw_post_handler(httpd_req_t *req);
 
 /* About-Handler */
 esp_err_t about_get_handler(httpd_req_t *req);

--- a/src/urihandler/uploadfwhandler.c
+++ b/src/urihandler/uploadfwhandler.c
@@ -1,0 +1,115 @@
+// Custom-firmware upload via POST /uploadfw.
+//
+// Body is the raw .bin (no multipart). The frontend in ota.html submits the
+// File object directly via fetch(). We stream chunks straight into
+// esp_ota_write() so memory use is bounded regardless of image size, set the
+// inactive partition as the boot target, and trigger a restart.
+
+#include <esp_log.h>
+#include <esp_ota_ops.h>
+#include <esp_http_server.h>
+#include <esp_partition.h>
+#include <string.h>
+
+#include "handler.h"
+#include "timer.h"
+
+static const char *TAG = "UploadFW";
+
+#define UPLOAD_CHUNK_SIZE 4096
+
+static esp_err_t reply_error(httpd_req_t *req, int code, const char *status, const char *msg)
+{
+    ESP_LOGE(TAG, "%s: %s", status, msg);
+    httpd_resp_set_status(req, status);
+    httpd_resp_set_type(req, "text/plain");
+    httpd_resp_sendstr(req, msg);
+    return code;
+}
+
+esp_err_t uploadfw_post_handler(httpd_req_t *req)
+{
+    if (isLocked())
+    {
+        return redirectToLock(req);
+    }
+
+    const esp_partition_t *part = esp_ota_get_next_update_partition(NULL);
+    if (!part)
+    {
+        return reply_error(req, ESP_OK, "500 Internal Server Error", "no OTA partition");
+    }
+    ESP_LOGI(TAG, "writing to partition %s (size %u)", part->label, (unsigned)part->size);
+
+    int total = req->content_len;
+    if (total <= 0)
+    {
+        return reply_error(req, ESP_OK, "411 Length Required", "Content-Length required");
+    }
+    if ((size_t)total > part->size)
+    {
+        return reply_error(req, ESP_OK, "413 Payload Too Large", "firmware larger than OTA partition");
+    }
+
+    esp_ota_handle_t handle = 0;
+    esp_err_t err = esp_ota_begin(part, total, &handle);
+    if (err != ESP_OK)
+    {
+        return reply_error(req, ESP_OK, "500 Internal Server Error", esp_err_to_name(err));
+    }
+
+    char *buf = malloc(UPLOAD_CHUNK_SIZE);
+    if (!buf)
+    {
+        esp_ota_abort(handle);
+        return reply_error(req, ESP_OK, "500 Internal Server Error", "no memory");
+    }
+
+    int received = 0;
+    while (received < total)
+    {
+        int want = total - received;
+        if (want > UPLOAD_CHUNK_SIZE)
+            want = UPLOAD_CHUNK_SIZE;
+        int n = httpd_req_recv(req, buf, want);
+        if (n <= 0)
+        {
+            if (n == HTTPD_SOCK_ERR_TIMEOUT)
+                continue;
+            ESP_LOGE(TAG, "recv failed at %d/%d (n=%d)", received, total, n);
+            free(buf);
+            esp_ota_abort(handle);
+            return reply_error(req, ESP_OK, "400 Bad Request", "upload truncated");
+        }
+        err = esp_ota_write(handle, buf, n);
+        if (err != ESP_OK)
+        {
+            ESP_LOGE(TAG, "ota_write failed at %d: %s", received, esp_err_to_name(err));
+            free(buf);
+            esp_ota_abort(handle);
+            return reply_error(req, ESP_OK, "500 Internal Server Error", esp_err_to_name(err));
+        }
+        received += n;
+    }
+    free(buf);
+
+    err = esp_ota_end(handle);
+    if (err != ESP_OK)
+    {
+        // ESP_ERR_OTA_VALIDATE_FAILED commonly means a bad image signature/header.
+        return reply_error(req, ESP_OK, "400 Bad Request", esp_err_to_name(err));
+    }
+    err = esp_ota_set_boot_partition(part);
+    if (err != ESP_OK)
+    {
+        return reply_error(req, ESP_OK, "500 Internal Server Error", esp_err_to_name(err));
+    }
+
+    ESP_LOGI(TAG, "upload OK (%d bytes), rebooting", received);
+    httpd_resp_set_status(req, "200 OK");
+    httpd_resp_set_type(req, "text/plain");
+    httpd_resp_sendstr(req, "OK; restarting");
+
+    restartByTimerinS(2);
+    return ESP_OK;
+}


### PR DESCRIPTION
`/ota` only fetches a hardcoded GitHub URL — breaks any workflow that wants to flash a dev build or a fork without USB access.

`POST /uploadfw` accepts the firmware as the raw request body (no multipart). The handler streams 4 KB chunks straight into `esp_ota_write()` on the inactive partition, calls `esp_ota_set_boot_partition()`, schedules a 2s restart via the existing `restartByTimerinS()`. Lock-aware. NVS untouched, settings survive.

`pages/ota.html` adds a file picker + a confirm-on-click button + an inline progress bar; XHR with `Content-Type: application/octet-stream`.

Tested live: 1.4 MB upload → HTTP 200 in 8.8s → reboot in ~1s → device back on the same IP with all settings.

Complements #176 (edit the OTA URL instead of replacing the path). First commit is a build-fix shared with #174/#176.