### PR TITLE
OTA: make the source URL editable on the Advanced page

### DIFF
--- a/components/cmd_system/cmd_system.c
+++ b/components/cmd_system/cmd_system.c
@@ -16,6 +16,7 @@
 #include "esp_sleep.h"
 #include "spi_flash_mmap.h"
 #include "driver/rtc_io.h"
+#include "driver/gpio.h"
 #include "driver/uart.h"
 #include "argtable3/argtable3.h"
 #include "freertos/FreeRTOS.h"

--- a/src/pages/advanced.html
+++ b/src/pages/advanced.html
@@ -200,6 +200,18 @@
                                         clients connected to the upstream network. This changes both the IP of the
                                         router and the IP of all connected clients.</div>
                         </div>
+                        <h2>OTA update source</h2>
+                        <div class="form-group row mt-2">
+                                <label class="form-label" for="ota_url">Custom OTA URL</label>
+                                <input class="form-control mt-2" id="ota_url" maxlength="200" name="ota_url"
+                                                placeholder="https://example.com/path/ (leave blank for default)"
+                                                type="text" value="%s">
+                                <small class="form-text text-muted mt-2">Overrides the source URL used by the
+                                        "Install latest version" button on the <a href="/ota">OTA page</a>. If set,
+                                        the device fetches <code>firmware.bin</code> directly from this URL (chip
+                                        suffix is NOT appended). Leave blank to fall back to the upstream release
+                                        branch.</small>
+                        </div>
                         <div class="form-group row col-4 offset-4 mt-4"> <input class="btn btn-primary" type=submit
                                         value="Apply"> </div> <input type=hidden value=x name=x>
                 </form>

--- a/src/urihandler/advancedhandler.c
+++ b/src/urihandler/advancedhandler.c
@@ -165,6 +165,12 @@ esp_err_t advanced_download_get_handler(httpd_req_t *req)
     get_config_param_str("ota_url", &otaUrl);
     if (otaUrl == NULL)
         otaUrl = "";
+    // HTML-escape before interpolating into the value="%s" attribute below.
+    // ota_url is user-controlled (set via this same page / apply handler and
+    // persisted in NVS), so an unescaped value would be stored XSS.
+    char *otaUrlEsc = html_escape(otaUrl);
+    if (otaUrlEsc == NULL)
+        otaUrlEsc = strdup("");
 
     char *netmask = getNetmask();
 
@@ -187,7 +193,7 @@ esp_err_t advanced_download_get_handler(httpd_req_t *req)
         customMask = netmask;
     }
 
-    u_int size = advanced_html_size + strlen(aliveCB) + strlen(ledCB) + strlen(natCB) + strlen(currentDNS) + strlen(currentMAC) + 3 * strlen("checked") + strlen(customDNSIP) + 2 * strlen(defaultMAC) + strlen(customMac) + strlen(netmask) + strlen(hostName) + 2 * strlen("selected") + strlen(customMask) + strlen(otaUrl) + 4 /* 4 * Octet - 4 *%d*/;
+    u_int size = advanced_html_size + strlen(aliveCB) + strlen(ledCB) + strlen(natCB) + strlen(currentDNS) + strlen(currentMAC) + 3 * strlen("checked") + strlen(customDNSIP) + 2 * strlen(defaultMAC) + strlen(customMac) + strlen(netmask) + strlen(hostName) + 2 * strlen("selected") + strlen(customMask) + strlen(otaUrlEsc) + 4 /* 4 * Octet - 4 *%d*/;
     ESP_LOGI(TAG, "Allocating additional %d bytes for advanced page.", size);
     char *advanced_page = malloc(size);
 
@@ -196,7 +202,8 @@ esp_err_t advanced_download_get_handler(httpd_req_t *req)
 
     subMac[strlen(subMac) - 2] = '\0';
 
-    sprintf(advanced_page, advanced_start, hostName, octet, lowSelected, mediumSelected, highSelected, bwHigh, bwLow, ledCB, aliveCB, natCB, currentDNS, defCB, cloudCB, adguardCB, customCB, customDNSIP, currentMAC, defMacCB, defaultMAC, rndMacCB, subMac, customMacCB, customMac, netmask, classCCB, octet, classBCB, octet, classACB, octet, customMaskCB, customMask, otaUrl);
+    sprintf(advanced_page, advanced_start, hostName, octet, lowSelected, mediumSelected, highSelected, bwHigh, bwLow, ledCB, aliveCB, natCB, currentDNS, defCB, cloudCB, adguardCB, customCB, customDNSIP, currentMAC, defMacCB, defaultMAC, rndMacCB, subMac, customMacCB, customMac, netmask, classCCB, octet, classBCB, octet, classACB, octet, customMaskCB, customMask, otaUrlEsc);
+    free(otaUrlEsc);
 
     closeHeader(req);
     esp_err_t ret = httpd_resp_send(req, advanced_page, HTTPD_RESP_USE_STRLEN);

--- a/src/urihandler/advancedhandler.c
+++ b/src/urihandler/advancedhandler.c
@@ -161,6 +161,11 @@ esp_err_t advanced_download_get_handler(httpd_req_t *req)
         customMac = currentMAC;
     }
 
+    char *otaUrl = "";
+    get_config_param_str("ota_url", &otaUrl);
+    if (otaUrl == NULL)
+        otaUrl = "";
+
     char *netmask = getNetmask();
 
     if (strcmp(netmask, DEFAULT_NETMASK_CLASS_A) == 0)
@@ -182,7 +187,7 @@ esp_err_t advanced_download_get_handler(httpd_req_t *req)
         customMask = netmask;
     }
 
-    u_int size = advanced_html_size + strlen(aliveCB) + strlen(ledCB) + strlen(natCB) + strlen(currentDNS) + strlen(currentMAC) + 3 * strlen("checked") + strlen(customDNSIP) + 2 * strlen(defaultMAC) + strlen(customMac) + strlen(netmask) + strlen(hostName) + 2 * strlen("selected") + strlen(customMask) + 4 /* 4 * Octet - 4 *%d*/;
+    u_int size = advanced_html_size + strlen(aliveCB) + strlen(ledCB) + strlen(natCB) + strlen(currentDNS) + strlen(currentMAC) + 3 * strlen("checked") + strlen(customDNSIP) + 2 * strlen(defaultMAC) + strlen(customMac) + strlen(netmask) + strlen(hostName) + 2 * strlen("selected") + strlen(customMask) + strlen(otaUrl) + 4 /* 4 * Octet - 4 *%d*/;
     ESP_LOGI(TAG, "Allocating additional %d bytes for advanced page.", size);
     char *advanced_page = malloc(size);
 
@@ -191,7 +196,7 @@ esp_err_t advanced_download_get_handler(httpd_req_t *req)
 
     subMac[strlen(subMac) - 2] = '\0';
 
-    sprintf(advanced_page, advanced_start, hostName, octet, lowSelected, mediumSelected, highSelected, bwHigh, bwLow, ledCB, aliveCB, natCB, currentDNS, defCB, cloudCB, adguardCB, customCB, customDNSIP, currentMAC, defMacCB, defaultMAC, rndMacCB, subMac, customMacCB, customMac, netmask, classCCB, octet, classBCB, octet, classACB, octet, customMaskCB, customMask);
+    sprintf(advanced_page, advanced_start, hostName, octet, lowSelected, mediumSelected, highSelected, bwHigh, bwLow, ledCB, aliveCB, natCB, currentDNS, defCB, cloudCB, adguardCB, customCB, customDNSIP, currentMAC, defMacCB, defaultMAC, rndMacCB, subMac, customMacCB, customMac, netmask, classCCB, octet, classBCB, octet, classACB, octet, customMaskCB, customMask, otaUrl);
 
     closeHeader(req);
     esp_err_t ret = httpd_resp_send(req, advanced_page, HTTPD_RESP_USE_STRLEN);

--- a/src/urihandler/applyhandler.c
+++ b/src/urihandler/applyhandler.c
@@ -328,6 +328,23 @@ void applyAdvancedConfig(char *buf)
         nvs_erase_key(nvs, "hostname");
     }
 
+    {
+        // OTA source URL. Empty input clears the override → fall back to upstream default.
+        // Buffer needs to be large enough for full URL; reuse a sized stack buffer.
+        char otaParam[256];
+        readUrlParameterIntoBuffer(buf, "ota_url", otaParam, sizeof(otaParam));
+        if (strlen(otaParam) > 0)
+        {
+            ESP_LOGI(TAG, "Set ota_url to: %s", otaParam);
+            ESP_ERROR_CHECK(nvs_set_str(nvs, "ota_url", otaParam));
+        }
+        else
+        {
+            ESP_LOGI(TAG, "Clearing custom ota_url (using upstream default)");
+            nvs_erase_key(nvs, "ota_url");
+        }
+    }
+
     readUrlParameterIntoBuffer(buf, "octet", param, contentLength);
     int octet = atoi(param);
     if (strlen(param) > 0 && octet >= 0 && octet <= 255)

--- a/src/urihandler/helper.c
+++ b/src/urihandler/helper.c
@@ -1,7 +1,77 @@
 #include "helper.h"
 #include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
 
 static const char *TAG = "urihelper";
+
+char *html_escape(const char *src)
+{
+    if (src == NULL)
+    {
+        src = "";
+    }
+    size_t len = 0;
+    for (const char *p = src; *p != '\0'; p++)
+    {
+        switch (*p)
+        {
+        case '&':
+            len += 5; // &amp;
+            break;
+        case '<':
+        case '>':
+            len += 4; // &lt; / &gt;
+            break;
+        case '"':
+            len += 6; // &quot;
+            break;
+        case '\'':
+            len += 5; // &#39;
+            break;
+        default:
+            len += 1;
+            break;
+        }
+    }
+    char *out = malloc(len + 1);
+    if (out == NULL)
+    {
+        return NULL;
+    }
+    char *q = out;
+    for (const char *p = src; *p != '\0'; p++)
+    {
+        switch (*p)
+        {
+        case '&':
+            memcpy(q, "&amp;", 5);
+            q += 5;
+            break;
+        case '<':
+            memcpy(q, "&lt;", 4);
+            q += 4;
+            break;
+        case '>':
+            memcpy(q, "&gt;", 4);
+            q += 4;
+            break;
+        case '"':
+            memcpy(q, "&quot;", 6);
+            q += 6;
+            break;
+        case '\'':
+            memcpy(q, "&#39;", 5);
+            q += 5;
+            break;
+        default:
+            *q++ = *p;
+            break;
+        }
+    }
+    *q = '\0';
+    return out;
+}
 
 void preprocess_string(char *str)
 {

--- a/src/urihandler/helper.h
+++ b/src/urihandler/helper.h
@@ -7,3 +7,6 @@ void preprocess_string(char *str);
 void readUrlParameterIntoBuffer(char *parameterString, char *parameter, char *buffer, size_t paramLength);
 esp_err_t fill_post_buffer(httpd_req_t *req, char *buf, size_t len);
 bool is_valid_subnet_mask(char *subnet_mask);
+// Returns a newly malloc'd, HTML-attribute-safe copy of src (escapes
+// & < > " '). Caller must free(). Returns NULL only on allocation failure.
+char *html_escape(const char *src);

--- a/src/urihandler/otahandler.c
+++ b/src/urihandler/otahandler.c
@@ -347,9 +347,17 @@ esp_err_t ota_download_get_handler(httpd_req_t *req)
     char customUrl[200];
     char label[20];
     getOtaUrl(customUrl, label);
+    // HTML-escape ota_url (customUrl) before rendering it into the
+    // href="%s" attribute on the OTA page — it's user-controlled (editable
+    // on the Advanced page, persisted in NVS), so an unescaped value is
+    // stored XSS. label is a fixed string (Custom/Default/Canary build).
+    char *customUrlEsc = html_escape(customUrl);
+    if (customUrlEsc == NULL)
+        customUrlEsc = strdup("");
     const char *project_version = get_project_version();
-    char *ota_page = malloc(ota_html_size + strlen(project_version) + strlen(customUrl) + strlen(latest_version) + strlen(chip_type) + strlen(label) + strlen(changelog));
-    sprintf(ota_page, ota_start, project_version, latest_version, changelog, customUrl, label, chip_type);
+    char *ota_page = malloc(ota_html_size + strlen(project_version) + strlen(customUrlEsc) + strlen(latest_version) + strlen(chip_type) + strlen(label) + strlen(changelog));
+    sprintf(ota_page, ota_start, project_version, latest_version, changelog, customUrlEsc, label, chip_type);
+    free(customUrlEsc);
 
     closeHeader(req);
 


### PR DESCRIPTION
`otahandler.c::getOtaUrl()` already reads NVS key `ota_url` and falls back to the upstream default if unset — but the only way to set it has been the serial-console `nvs_set` command. Useless if you want to point the router at a fork without USB access.

This exposes it as a text input on `/advanced`. Empty input → `nvs_erase_key` (falls back to upstream default). Non-empty → `nvs_set_str`.

Caveat (existing `getOtaUrl()` semantics, just exposed here): when `ota_url` is set, it's used verbatim — the chip-type suffix `+ chip_type + "/firmware.bin"` is **not** appended. Documented inline via a `<small>` note.

Tested live: POST sets the URL → reboot → GET shows the persisted value; empty POST clears it.

Complements #175 (raw upload). First commit is a build-fix shared with #174/#175.